### PR TITLE
updated esprima within reqursive/detective for modern ES support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "uglify-js": "~1.3.3",
     "mousetrap": "0.0.1"
   },
+  "resolutions": {
+    "reqursive/detective": "5.1.0"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/hughsk/colony.git"


### PR DESCRIPTION
This isn't a serious pull request (as the project appears to be unmaintained), but it fixes your typical `Unexpected token` errors when running colony on modern codebases.

You must install the dependencies using `yarn` to take advantages of this field. But everything appears to work! 

probably fixes #17, #18 

--------

Also to anyone else curious: https://github.com/tomek-f/colony-fixed has slightly more updated dependencies and doesn't require this yarn-only hack. (Untested, so it probably still requires a bump here or there)